### PR TITLE
Add English translations for tickets and elePHPant

### DIFF
--- a/2019/en/elephpant.html
+++ b/2019/en/elephpant.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-91139113-1"></script>
+	<script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-91139113-1');
+	</script>
+	<base href="https://php.darkmiratour.rocks/2019/" />
+	<meta charset="utf-8" />
+	<link rel="icon" type="image/png" href="assets/img/favicon.ico">
+	<link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+
+	<title>Darkmira Tour PHP 2019 - ElePHPant</title>
+
+	<meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
+	<meta name="viewport" content="width=device-width" />
+
+	<link href="assets/css/bootstrap.min.css" rel="stylesheet" />
+	<link href="assets/css/paper-kit.css?v=2.1.20" rel="stylesheet"/>
+	<link href="assets/css/demo.css" rel="stylesheet" />
+
+	<!--     Fonts and icons     -->
+	<link href='https://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
+	<link href="https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css" rel="stylesheet">
+	<link href="assets/css/nucleo-icons.css" rel="stylesheet">
+
+</head>
+<body>
+<nav class="navbar navbar-expand-lg fixed-top navbar-transparent nav-down" color-on-scroll="500">
+	<div class="container">
+		<div class="navbar-translate">
+			<div class="navbar-header">
+				<a class="navbar-brand" href="../index.html">Darkmira Tour PHP 2019</a>
+			</div>
+			<button class="navbar-toggler navbar-burger" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+				<span class="navbar-toggler-bar"></span>
+				<span class="navbar-toggler-bar"></span>
+				<span class="navbar-toggler-bar"></span>
+			</button>
+		</div>
+		<div class="collapse navbar-collapse">
+			<ul class="navbar-nav ml-auto">
+				<li class="nav-item dropdown">
+					<a class="nav-link dropdown-toggle" href="javascript:void(0)" data-toggle="dropdown">Past Editions</a>
+					<ul class="dropdown-menu dropdown-menu-right dropdown-danger">
+						<a class="dropdown-item" href="https://php.darkmiratour.rocks/2017"><i class="nc-icon nc-tile-56"></i>&nbsp; 2017</a>
+						<a class="dropdown-item" href="https://php.darkmiratour.rocks/2018"><i class="nc-icon nc-tile-56"></i>&nbsp; 2018</a>
+					</ul>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="index.html" data-scroll="true">Event</a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="index.html#workshops" data-scroll="true">Workshops</a>
+				</li>
+				<li class="nav-item">
+					<a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0 7px 10px;"><i class="fa fa-twitter"></i></a>
+					<a href="https://www.facebook.com/pg/darkmiratour/posts/" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0;"><i class="fa fa-facebook"></i></a>
+					<a href="https://php.darkmiratour.rocks/2019/" class="btn btn-link btn-neutral" style="padding: 7px 0;"><img src="assets/img/pt-br.png" alt="Português" /></a>
+					<a href="https://php.darkmiratour.rocks/2019/en/" class="btn btn-link btn-neutral" style="padding: 7px 0;"><img src="assets/img/en.png" alt="English" /></a>
+				</li>
+			</ul>
+		</div>
+	</div>
+</nav>
+
+<div class="page-header" data-parallax="true" style="min-height: 70vh; background-image: url('assets/img/sections/elephpants.jpg');">
+	<div class="filter"></div>
+	<div class="content-center">
+		<div class="container">
+			<div class="motto">
+				<h2 style="font-weight:bold; margin:0; text-shadow: #333 1px 1px 5px;">ElePHPant</h2>
+				<p style="font-size:24px; margin-top: 10px; text-shadow: #000 1px 1px 2px;">The exclusive and unprecedented plush ElePHPant from Brazil</p>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="wrapper">
+	<div class="testimonials-1 section-image" style="background-image: url('assets/img/sections/pexels-photo-154147.jpg')">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-6 ml-auto mr-auto text-center">
+					<h2 class="title">I drew and created the mascot elephpant...</h2>
+				</div>
+			</div>
+			<div class="space-top"></div>
+			<div class="row">
+				<div class="col-md-12">
+					<div class="card card-testimonial">
+						<div class="card-icon">
+							<i class="fa fa-quote-right" aria-hidden="true"></i>
+						</div>
+						<div class="card-body">
+							<p class="card-description" style="font-size: 14pt;">
+								I drew and created the mascot elephpant in 1998 on an autumn night.
+								Since then, elePHPant has made its own way.
+
+								<br><br>
+
+								It is known and distributed in over 78 countries worldwide. What beautiful memories I still have of these pioneering years. I am so happy to have known this era when the two words "free" and "sharing" made sense in the PHP community.
+
+								<br><br>
+
+								And to pay tribute to these years of foundation I decided to exceptionally offer the value of my copyrights to <a href="https://twitter.com/CyrilleGrandval">Cyrille GRANDVAL</a> for the launch of his special elePHPant from Brazil. This small, punctual gesture, hopefully, will allow your next event to be a real success! Thanks to Cyrille for embodying today the values that have made the success of PHP: Mutual support, solidarity and kindness. Long Live!
+
+								<br><br>
+
+								Kindly
+							</p>
+							<div class="card-footer">
+								<h4 class="card-title">Vincent Pontier</h4>
+								<h6 class="card-category"><a href="https://twitter.com/Elroubio">@Elroubio</a></h6>
+								<div class="card-avatar">
+									<a href="https://twitter.com/Elroubio">
+										<img class="img" src="assets/img/faces/vincent_pontier.jpg" />
+									</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div id="elephpant">
+	<div class="section section-gray text-center landing-section">
+		<div class="row">
+			<div class="col-md-8 ml-auto mr-auto text-center">
+				<h2 class="title">Special Edition Brasil Elephpant</h2>
+				<h5 class="description">Known and distributed in more than 78 countries around the world, now is thime for the PHP communities of Brazil to have their own PHP plush.</h5>
+			</div>
+		</div>
+		<br>
+		<div class="row">
+			<div class="col-md-1"></div>
+
+			<div class="col-md-6">
+				<div class="ipad-container">
+					<img style="width: 100%;" src="assets/img/sections/elephant-brasil.png" />
+				</div>
+			</div>
+
+			<div class="col-md-4 offset-1">
+				<br>
+				<h4>100% of the profits of the sales will serve for actions of diversity of the event, such as:</h4>
+
+				<div class="info info-horizontal">
+					<div class="icon icon-info">
+						<i class="fa fa-users" aria-hidden="true"></i>
+					</div>
+					<div class="description">
+						<h4 class="info-title">Transportation of participants</h4>
+						<p>Transportation of participants residing in the interior of the state of Ceará and do not have financial means to get to the capital.</p>
+					</div>
+				</div>
+
+				<div class="info info-horizontal">
+					<div class="icon icon-danger">
+						<i class="fa fa-female" aria-hidden="true"></i>
+					</div>
+					<div class="description">
+						<h4 class="info-title">Free and exclusive course for women</h4>
+						<p>An entirely free and exclusive PHP course for women who are starting their IT career, thus fostering their participation in the event.</p>
+					</div>
+				</div>
+				<div class="info info-horizontal">
+					<div class="icon icon-danger">
+						<i class="fa fa-money" aria-hidden="true"></i>
+					</div>
+					<div class="description">
+						<h4 class="info-title">Low-price ticket</h4>
+						<p>Assist in lowering the price of tickets, making them more accessible.</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="cd-section" id="sociais">
+	<div class="section section-dark text-center">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-8 ml-auto mr-auto">
+					<h2 class="title">Follow us and share with <a class="text-success" href="https://twitter.com/search?q=%23DarkmiraTour&src=typd" target="_blank">#DarkmiraTour</a></h2>
+				</div>
+				<br/>
+			</div>
+			<div class="row">
+				<div class="col-md-12">
+					<p>
+						<a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-just-icon btn-twitter"><i class="fa fa-twitter"></i></a>
+						<a href="https://www.facebook.com/pg/darkmiratour/posts/" target="_blank" class="btn btn-just-icon btn-facebook"><i class="fa fa-facebook"></i></a>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<footer class="footer section-dark">
+	<div class="container">
+		<div class="row">
+			<nav class="footer-nav">
+				<ul>
+					<li><a href="../index.html">Darkmira Tour PHP 2019</a></li>
+				</ul>
+			</nav>
+			<div class="credits ml-auto">
+					<span class="copyright">
+						Made with <i class="fa fa-heart heart"></i> with Paper Kit 2 Pro
+					</span>
+			</div>
+		</div>
+	</div>
+</footer>
+</body>
+
+<!-- Core JS Files -->
+<script src="assets/js/jquery-3.2.1.min.js" type="text/javascript"></script>
+<script src="assets/js/jquery-ui-1.12.1.custom.min.js" type="text/javascript"></script>
+<script src="assets/js/popper.js" type="text/javascript"></script>
+<script src="assets/js/bootstrap.min.js" type="text/javascript"></script>
+
+<!-- Control Center for Paper Kit: parallax effects, scripts for the example pages etc -->
+<script src="assets/js/paper-kit.js?v=2.1.0"></script>
+
+<!--  Plugins for Select -->
+<script src="assets/js/bootstrap-select.js"></script>
+<script src="assets/js/demo.js"></script>
+
+<!--  Plugins for Map -->
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDfQnvmEyR79sLYapgptpme-I2c9n-vf1Q&language=pt-br"></script>
+
+<script type="text/javascript">
+    $().ready(function(){
+        demo.initContactUsMap2()
+    });
+</script>
+</html>

--- a/2019/en/index.html
+++ b/2019/en/index.html
@@ -56,6 +56,15 @@
                         <a class="nav-link" href="index.html#evento" data-scroll="true" href="javascript:void(0)">Event</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="elephpant.html" data-scroll="true">ElePHPant</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="index.html#workshops" data-scroll="true" href="javascript:void(0)">Workshops</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="index.html#tickets" data-scroll="true" href="javascript:void(0)">Tickets</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0 7px 10px;"><i class="fa fa-twitter"></i></a>
                         <a href="https://www.facebook.com/pg/darkmiratour/posts/" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0;"><i class="fa fa-facebook"></i></a>
                         <a href="https://php.darkmiratour.rocks/2019/" class="btn btn-link btn-neutral" style="padding: 7px 0;"><img src="assets/img/pt-br.png" alt="Português" /></a>
@@ -79,9 +88,9 @@
                         <h1 style="font-weight:bold; margin:0; text-shadow: #333 1px 1px 5px;">Darkmira Tour PHP 2019</h1>
                         <p style="font-size:24px; margin-top: 10px; text-shadow: #000 1px 1px 2px;">The unmissable event about<br/> Security and quality in PHP ecosystems</p>
                     </div>
-                    <a href="https://dmtphp.io/flickr" target="_blank" class="btn btn-outline-neutral btn-round">See our photos</a>
-                    <a href="https://dmtphp.io/twitter" target="_blank" class="btn btn-outline-neutral btn-round">Follow us on Twitter</a>
-                    <a href="https://dmtphp.io/telegram" target="_blank" class="btn btn-outline-neutral btn-round">Join us on Telegram (pt)</a>
+                    <a href="https://www.flickr.com/photos/darkmiratour/" target="_blank" class="btn btn-outline-neutral btn-round">See our photos</a>
+                    <a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-outline-neutral btn-round">Follow us on Twitter</a>
+                    <a href="https://t.me/darkmiratour" target="_blank" class="btn btn-outline-neutral btn-round">Join us on Telegram (pt)</a>
 	            </div>
 	        </div>
 		</div>
@@ -135,6 +144,326 @@
     					</div>
     				</div>
 
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="cd-section section-white" id="workshops">
+        <div class="team-2 section-image" style="background-image: url('assets/img/sections/pexels-photo-154147.jpg')">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-8 ml-auto mr-auto text-center">
+                        <h2 class="title">Workshops with experts</h2>
+                        <h4 class="text-white">A full day (Friday, June 07) with 3 simultaneous workshops of 8 hours of duration for you to choose, with the best professionals in the PHP community.</h4>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4">
+                        <div class="card card-profile card-plain">
+                            <div class="card-img-top">
+                                <a href="#workshops">
+                                    <img class="img" src="assets/img/faces/Wellington-Silva-square.png" />
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                <h4 class="card-title"><strong>Wellington F. Silva</strong></h4>
+                                <h5 class="card-category text-warning"><strong>Docker na Prática sem arrudeio</strong></h5>
+                                <p class="card-category"><em>Workshop in Portugese</em></p>
+                                <p class="card-description text-center">
+                                	Certificado ZCE PHP, Autor do livro <a class="text-info" href="https://novatec.com.br/livros/aprendendo-docker/">Aprendendo Docker, do básico à orquestração de contêineres</a> publicado pela editora Novatec. Co-organizador do meetup de Docker em São Paulo, tem background em telecomunicações, VoIP e Linux. Tem contribuído com suporte em fóruns, grupos de Slack e Telegram, dando palestras para as comunidades PHP, Python e Go.
+                                </p>
+                                <div class="card-footer">
+                                    <a href="https://twitter.com/_wsilva" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-twitter"></i></a>
+                                    <a href="https://www.linkedin.com/in/wfsilva" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-linkedin"></i></a>
+                                    <a href="https://www.facebook.com/silva.tom" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-facebook"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-md-4">
+                        <div class="card card-profile card-plain">
+                            <div class="card-img-top">
+                                <a href="#workshops">
+                                    <img class="img" src="assets/img/faces/Junior-Grossi-square.png" />
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                <h4 class="card-title"><strong>Junior Grossi</strong></h4>
+                                <h5 class="card-category text-warning"><strong>Code quality: A practical summary of what every dev needs to know</strong></h5>
+                                <p class="card-description text-center">
+                                	Organizer of PHPMG and Software Engineer at InterNACHI (USA). PhD student in information science at UFMG. Creator of the PHP Corcel and ElePHPant collector. Open-source enthusiast and defender of remote work. Husband and devoted father of two.
+                                </p>
+                                <div class="card-footer">
+                                    <a href="https://twitter.com/junior_grossi" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-twitter"></i></a>
+                                    <a href="https://www.linkedin.com/in/juniorgrossi/" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-linkedin"></i></a>
+                                    <a href="https://www.facebook.com/gr0ssi" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-facebook"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-md-4">
+                        <div class="card card-profile card-plain">
+                            <div class="card-img-top">
+                                <a href="#workshops">
+                                    <img class="img" src="assets/img/faces/Evandro-Mohr-square.png" />
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                <h4 class="card-title"><strong>Evandro Mohr</strong></h4>
+                                <h5 class="card-category text-warning"><strong>Security in practice: Hacking your PHP application</strong></h5>
+                                <p class="card-description text-center">
+                                    Evandro Mohr was a professor at the State University of Vale do Acaraú and has worked as a developer and IT manager in the Government of the state of Ceará for almost a decade.
+                                    He currently works with software development at Objective Solutions in Curitiba and, in his spare time, likes to fly airplanes in the south of the country.
+                                </p>
+                                <div class="card-footer">
+                                    <a href="https://www.linkedin.com/in/evandromohr/" target="_blank" class="btn btn-link btn-just-icon btn-neutral"><i class="fa fa-linkedin"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="features-2">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8 ml-auto mr-auto text-center">
+                    <h2 class="title">How about a special stuffed elephpant?</h2>
+                    <h5 class="description">The 2019 edition is very special, for the first time ever we will have a plush ElePHPant exclusive to the Darkmira PHP Tour.</h5>
+                    <br/>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="card" data-background="image" style="background-image: url('assets/img/sections/elephant-side-right.png')">
+                        <div class="card-body">
+                            <h4 class="card-category">Diversity</h4>
+                            <div class="card-icon">
+                                <i class="nc-icon nc-world-2"></i>
+                            </div>
+                            <div class="card-footer">
+                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                    <i class="fa fa-book" aria-hidden="true"></i> Learn More
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card" data-background="image" style="background-image: url('assets/img/sections/elephant-side-front.png')">
+                        <div class="card-body">
+                            <h4 class="card-category">Exclusive Design</h4>
+                            <div class="card-icon">
+                                <i class="fa fa-pencil"></i>
+                            </div>
+                            <div class="card-footer">
+                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                    <i class="fa fa-book" aria-hidden="true"></i> Learn More
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card" data-background="image" style="background-image: url('assets/img/sections/elephant-side-left.png')">
+                        <div class="card-body">
+                            <h4 class="card-category">A First in Brazil</h4>
+                            <div class="card-icon">
+                                <i class="fa fa-star"></i>
+                            </div>
+                            <div class="card-footer">
+                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                    <i class="fa fa-book" aria-hidden="true"></i> Learn More
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="pricing-5 section-dark">
+        <div class="">
+            <div class="row">
+                <div class="col-md-12 text-center">
+                    <h2 class="title">Guarantee your ticket and/or elephpant</h2>
+                    <div class="choose-plan">
+                        <ul class="nav nav-pills nav-pills-success justify-content-center" role="tablist">
+                            <li class="nav-item">
+                                <a class="nav-link active" data-toggle="tab" href="#ticketSimple" role="tab">Entry</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-toggle="tab" href="#ticketWorkshop" role="tab">Entry + Workshop</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-toggle="tab" href="#ticketElephpant" role="tab">ElePHPant</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <br/>
+                    <p class="description text-gray">You can buy just an elePHPant, but remember, you or someone needs to pick it up during the event.</p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="tab-content text-center" >
+                        <div class="tab-pane active" id="ticketSimple" role="tabpanel">
+                            <div class="space-top"></div>
+                            <div class="row">
+                                <div class="col-md-2"></div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing" data-color="green">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Early Bird</h6>
+                                            <h1 class="card-title">R$ 80</h1>
+                                            <ul>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Fee</b> aos sorteios de brindes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 12/12/2018 to 31/01/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Buy Now</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Phase 1</h6>
+                                            <h1 class="card-title">R$ 95</h1>
+                                            <ul>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 01/02/2019 to 31/03/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Not available</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Phase 2</h6>
+                                            <h1 class="card-title">R$ 115</h1>
+                                            <ul>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 01/04/2019 to 12/05/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Not available</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Phase 3</h6>
+                                            <h1 class="card-title">R$ 150</h1>
+                                            <ul>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 13/05/2019 to 09/06/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Not available</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="tab-pane" id="ticketWorkshop" role="tabpanel">
+                            <div class="space-top"></div>
+                            <div class="row">
+                                <div class="col-md-3"></div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing" data-color="green">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Early Bird + 1 Workshop</h6>
+                                            <h1 class="card-title">R$ 240</h1>
+                                            <ul>
+                                                <li><b>1 Workshop</b> 8 hours</li>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 17/12/2018 to 31/01/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Buy Now</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Lote 1 + 1 Workshop</h6>
+                                            <h1 class="card-title">R$ 275</h1>
+                                            <ul>
+                                                <li><b>1 Workshop</b> 8 hours</li>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 01/02/2019 to 31/03/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Not available</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Lote 2 + 1 Workshop</h6>
+                                            <h1 class="card-title">R$ 315</h1>
+                                            <ul>
+                                                <li><b>1 Workshop</b> 8 hours</li>
+                                                <li><b>Access</b> 2 days of lectures</li>
+                                                <li><b>1 T-shirt</b> - Event Edition</li>
+                                                <li><b>Participation</b> in the Giveaways &amp; Sweepstakes</li>
+                                                <li><b>Certificate</b> 20 hours of participation</li>
+                                                <li><b>Availability</b> 01/04/2019 to 12/05/2019</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-dark btn-round">Not available</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="tab-pane" id="ticketElephpant" role="tabpanel">
+                            <div class="space-top"></div>
+                            <div class="row">
+                                <div class="col-md-5"></div>
+                                <div class="col-md-2">
+                                    <div class="card card-pricing">
+                                        <div class="card-body">
+                                            <h6 class="card-category text-success">Plush ElePHPant</h6>
+                                            <h1 class="card-title">R$ 100</h1>
+                                            <ul>
+                                                <li><b>1</b> Plush ElePHPant</li>
+                                                <li><b>Pickup</b> only on the day of the event</li>
+                                                <li><b>No</b> access to the event</li>
+                                            </ul>
+                                            <a href="https://www.sympla.com.br/darkmira-tour-php-2019__420712" class="btn btn-success btn-round">Buy Now</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This fixes #9 and also adds an English page for the elePHPant.

* `Docker na Prática sem arrudeio` sounds like an idiomatic expression in Portuguese and I'm not sure what the correct translation is.
* For the ticket sales, I'm not sure what the context is of `Lote 1`/`Lote 1`/`Lote 3`.