### PR TITLE
Use full path URLs on en pages so links stay in en

### DIFF
--- a/2019/en/elephpant.html
+++ b/2019/en/elephpant.html
@@ -35,7 +35,7 @@
 	<div class="container">
 		<div class="navbar-translate">
 			<div class="navbar-header">
-				<a class="navbar-brand" href="../index.html">Darkmira Tour PHP 2019</a>
+				<a class="navbar-brand" href="/2019/en/index.html">Darkmira Tour PHP 2019</a>
 			</div>
 			<button class="navbar-toggler navbar-burger" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-bar"></span>
@@ -53,10 +53,10 @@
 					</ul>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="index.html" data-scroll="true">Event</a>
+					<a class="nav-link" href="/2019/en/index.html" data-scroll="true">Event</a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="index.html#workshops" data-scroll="true">Workshops</a>
+					<a class="nav-link" href="/2019/en/index.html#workshops" data-scroll="true">Workshops</a>
 				</li>
 				<li class="nav-item">
 					<a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0 7px 10px;"><i class="fa fa-twitter"></i></a>
@@ -211,7 +211,7 @@
 		<div class="row">
 			<nav class="footer-nav">
 				<ul>
-					<li><a href="../index.html">Darkmira Tour PHP 2019</a></li>
+					<li><a href="/2019/en/index.html">Darkmira Tour PHP 2019</a></li>
 				</ul>
 			</nav>
 			<div class="credits ml-auto">

--- a/2019/en/index.html
+++ b/2019/en/index.html
@@ -35,7 +35,7 @@
 		<div class="container">
 			<div class="navbar-translate">
 				<div class="navbar-header">
-					<a class="navbar-brand" href="index.html">Darkmira Tour PHP 2019</a>
+					<a class="navbar-brand" href="/2019/en/index.html">Darkmira Tour PHP 2019</a>
 				</div>
 				<button class="navbar-toggler navbar-burger" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-bar"></span>
@@ -53,16 +53,16 @@
                         </ul>
 					</li>
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html#evento" data-scroll="true" href="javascript:void(0)">Event</a>
+                        <a class="nav-link" href="/2019/en/index.html#evento" data-scroll="true" href="javascript:void(0)">Event</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="elephpant.html" data-scroll="true">ElePHPant</a>
+                        <a class="nav-link" href="/2019/en/elephpant.html" data-scroll="true">ElePHPant</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html#workshops" data-scroll="true" href="javascript:void(0)">Workshops</a>
+                        <a class="nav-link" href="/2019/en/index.html#workshops" data-scroll="true" href="javascript:void(0)">Workshops</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html#tickets" data-scroll="true" href="javascript:void(0)">Tickets</a>
+                        <a class="nav-link" href="/2019/en/index.html#tickets" data-scroll="true" href="javascript:void(0)">Tickets</a>
                     </li>
                     <li class="nav-item">
                         <a href="https://twitter.com/DarkmiraTour" target="_blank" class="btn btn-link btn-neutral" style="padding: 7px 0 7px 10px;"><i class="fa fa-twitter"></i></a>
@@ -249,7 +249,7 @@
                                 <i class="nc-icon nc-world-2"></i>
                             </div>
                             <div class="card-footer">
-                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                <a href="/2019/en/elephpant.html" class="btn btn-link btn-neutral">
                                     <i class="fa fa-book" aria-hidden="true"></i> Learn More
                                 </a>
                             </div>
@@ -264,7 +264,7 @@
                                 <i class="fa fa-pencil"></i>
                             </div>
                             <div class="card-footer">
-                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                <a href="/2019/en/elephpant.html" class="btn btn-link btn-neutral">
                                     <i class="fa fa-book" aria-hidden="true"></i> Learn More
                                 </a>
                             </div>
@@ -279,7 +279,7 @@
                                 <i class="fa fa-star"></i>
                             </div>
                             <div class="card-footer">
-                                <a href="elephpant.html" class="btn btn-link btn-neutral">
+                                <a href="/2019/en/elephpant.html" class="btn btn-link btn-neutral">
                                     <i class="fa fa-book" aria-hidden="true"></i> Learn More
                                 </a>
                             </div>
@@ -542,7 +542,7 @@
 			<div class="row">
 				<nav class="footer-nav">
 					<ul>
-						<li><a href="index.html">Darkmira Tour PHP 2019</a></li>
+						<li><a href="/2019/en/index.html">Darkmira Tour PHP 2019</a></li>
 					</ul>
 				</nav>
 				<div class="credits ml-auto">


### PR DESCRIPTION
I have absolutely no idea why this is happening but:

If I visit https://php.darkmiratour.rocks/2019/en/ (note that there ***is*** a trailing slash) and click the elePHPant link, it takes me to the Portugese version located in `/2019/` and *not* the `/2019/en/` version as I expected.  I can't figure out why this happens, so this PR just makes them absolute paths instead of relative paths as a workaround.